### PR TITLE
Force or not exception throw

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -105,7 +105,6 @@ class App
             $errorEvent = new HttpFlowEvent($eventName."_error", $request, $response);
             $errorEvent->setException($exception);
             $this->getContainer()->get("http.flow")->trigger($errorEvent);
-            throw $exception;
         }
 
         return $flowEvent->getResponse();

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -108,6 +108,7 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
         $this->app->getContainer()->get("http.flow")->attach("index.dummy_error", function ($e) use (&$count) {
             $count = &$count +1;
+            throw $e->getException();
         }, 10);
 
         $response = $this->app->run($request, $response);


### PR DESCRIPTION
At the moment I throw exception after exectution of all listener.
It's a good idea or not!?
