### PR TITLE
Create signature with route params

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -87,14 +87,16 @@ class App
         $event->setRouteInfo($routerInfo);
 
         $this->getContainer()->get("http.flow")->attach($eventName, function ($event) use ($controller, $method) {
-            $response = call_user_func_array(
-                [$controller, $method],
-                [
-                    $event->getRequest(),
-                    $event->getResponse(),
-                    $event->getRouteInfo()[2],
-                ]
-            );
+            $args = [
+                $event->getRequest(),
+                $event->getResponse(),
+            ];
+
+            foreach($event->getRouteInfo()[2] as $v) {
+                $args[] = $v;
+            }
+
+            $response = call_user_func_array([$controller, $method], $args);
             $event->setResponse($response);
         }, 0);
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -12,15 +12,10 @@ class AppTest extends \PHPUnit_Framework_TestCase
     public function setUp()
     {
         $router = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/', ['TestApp\Controller\Index', 'index'], [
-                "name" => "index"
-            ]);
-            $r->addRoute('GET', '/fail', ['TestApp\Controller\Index', 'failed'], [
-                "name" => "fail"
-            ]);
-            $r->addRoute('GET', '/dummy', ['TestApp\Controller\Index', 'dummy'], [
-                "name" => "dummy"
-            ]);
+            $r->addRoute('GET', '/', ['TestApp\Controller\Index', 'index']);
+            $r->addRoute('GET', '/{id:\d+}', ['TestApp\Controller\Index', 'getSingle']);
+            $r->addRoute('GET', '/fail', ['TestApp\Controller\Index', 'failed']);
+            $r->addRoute('GET', '/dummy', ['TestApp\Controller\Index', 'dummy']);
         });
 
         $this->app = new App($router);
@@ -59,6 +54,17 @@ class AppTest extends \PHPUnit_Framework_TestCase
 
         $response = $this->app->run($request, $response);
         $this->assertEquals(200, $response->getStatusCode());
+    }
+
+    public function testRouteParamIntoTheSignatureofMethod()
+    {
+        $request = (new \Zend\Diactoros\Request())
+        ->withUri(new \Zend\Diactoros\Uri('/10'))
+        ->withMethod("GET");
+        $response = new \Zend\Diactoros\Response();
+
+        $response = $this->app->run($request, $response);
+        $this->assertRegExp("/id=10/", $response->getBody()->__toString());
     }
 
     public function testEventPostExecuted()

--- a/tests/app/Controller/Index.php
+++ b/tests/app/Controller/Index.php
@@ -16,6 +16,12 @@ class Index
         return $response;
     }
 
+    public function getSingle(Request $request, Response $response, $id)
+    {
+        $response->getBody()->write("id=$id");
+        return $response;
+    }
+
     public function failed(Request $request, Response $response)
     {
         return $response->withStatus(502);


### PR DESCRIPTION
Now signature of method supports route params

``` php
$router = \FastRoute\simpleDispatcher(function (\FastRoute\RouteCollector $r) {
    $r->addRoute('GET', '/{id:\d+}', ['TestApp\Controller\Index', 'getSingle']);
});
$this->app = new \GianArb\Penny\App($router);
```

AppTest\Controller\Index

``` php
<?php
namespace TestApp\Controller;
use Zend\Diactoros\Request;
use Zend\Diactoros\Response;

class Index
{
    public function getSingle(Request $request, Response $response, $id)
    {
        $response->getBody()->write("id=$id");
        return $response;
    }
}
```
