### PR TITLE
PHP-DI bootstrap configuration

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -44,7 +44,7 @@ class App
      */
     public function __construct($router = null, ContainerInterface $container = null)
     {
-        $this->container = $container ?: $this->buildContainer(Loader::load());
+        $this->container = $container ?: static::buildContainer(Loader::load());
         $container = &$this->container;
 
         $this->response = new Response();
@@ -58,11 +58,6 @@ class App
             $container->set('router', $router);
         }
 
-        $container->set('event_manager', DI\object('Zend\EventManager\EventManager'));
-        $container->set(
-            'dispatcher',
-            DI\object('GianArb\Penny\Dispatcher')->constructor($container->get('router'))
-        );
         $container->set('di', $container);
     }
 
@@ -75,10 +70,15 @@ class App
      *
      * @return ContainerInterface
      */
-    private function buildContainer($config)
+    public static function buildContainer($config = [])
     {
         $builder = new DI\ContainerBuilder();
         $builder->useAnnotations(true);
+        $builder->addDefinitions([
+            "event_manager" =>  DI\object('Zend\EventManager\EventManager'),
+            "dispatcher" => DI\object('GianArb\Penny\Dispatcher')
+                ->constructor(DI\get('router')),
+        ]);
         $builder->addDefinitions($config);
 
         return $builder->build();

--- a/tests/AppLoaderTest.php
+++ b/tests/AppLoaderTest.php
@@ -41,11 +41,9 @@ class AppLoaderTest extends PHPUnit_Framework_TestCase
 
     public function testCorrectInjectionWithExternalContainer()
     {
-        $builder = new ContainerBuilder();
-        $builder->addDefinitions(Loader::load());
-        $builder->useAnnotations(true);
+        $container = App::buildContainer(Loader::load());
 
-        $app = new App($this->router, $builder->build());
+        $app = new App($this->router, $container);
 
         $request = (new Request())
         ->withUri(new Uri('/load'))

--- a/tests/DiTest.php
+++ b/tests/DiTest.php
@@ -21,11 +21,7 @@ class DiTest extends PHPUnit_Framework_TestCase
             $router->addRoute('GET', '/', ['TestApp\Controller\Index', 'diTest']);
         });
 
-        $builder = new ContainerBuilder();
-        $builder->useAnnotations(true);
-        $dic = $builder->build();
-
-        $this->container = $dic;
+        $this->container = App::buildContainer();
     }
 
     public function testInjectionHttpFlow()


### PR DESCRIPTION
App::buildContainer is a static method that helps to build a basic container
this update helps to create mocks (you can use it into the test to build
perfect container for our tests) and now the container builder is more clear

This PR maybe unlocks decorator feature (php-di) and follow this feedback (thanks @mnapoli)
https://github.com/pennyphp/penny-classic-app/pull/21#issuecomment-142745926

ping @samsonasik :)
