### PR TITLE
php-cs-fixer configuration

### DIFF
--- a/.php_cs
+++ b/.php_cs
@@ -1,0 +1,13 @@
+<?php
+
+$finder = Symfony\CS\Finder\DefaultFinder::create()
+    ->in(__DIR__)
+    ->exclude('docs')
+;
+
+return Symfony\CS\Config\Config::create()
+    ->fixers(array(
+        '-psr0',
+    ))
+    ->finder($finder)
+;

--- a/src/App.php
+++ b/src/App.php
@@ -4,7 +4,6 @@ namespace Penny;
 
 use Exception;
 use Penny\Config\Loader;
-use Penny\Container;
 use Penny\Event\HttpFlowEvent;
 use ReflectionClass;
 use Zend\Diactoros\Response;

--- a/src/Container/PHPDiFactory.php
+++ b/src/Container/PHPDiFactory.php
@@ -21,7 +21,7 @@ class PHPDiFactory
         $builder->useAnnotations(true);
         $builder->addDefinitions(
             [
-                'event_manager' =>  DI\object('Zend\EventManager\EventManager'),
+                'event_manager' => DI\object('Zend\EventManager\EventManager'),
                 'dispatcher' => DI\object('Penny\Dispatcher')
                     ->constructor(DI\get('router')),
             ]

--- a/tests/AppLoaderTest.php
+++ b/tests/AppLoaderTest.php
@@ -2,7 +2,6 @@
 
 namespace PennyTest;
 
-use DI\ContainerBuilder;
 use FastRoute;
 use Penny\App;
 use Penny\Container;
@@ -41,5 +40,4 @@ class AppLoaderTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(200, $response->getStatusCode());
         $this->assertEquals('eureka', $response->getBody()->__toString());
     }
-
 }

--- a/tests/DiTest.php
+++ b/tests/DiTest.php
@@ -2,7 +2,6 @@
 
 namespace PennyTest;
 
-use DI\ContainerBuilder;
 use Penny\Config\Loader;
 use FastRoute;
 use Penny\App;

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -65,7 +65,7 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
         ->withMethod('POST');
 
         $router->dispatch('POST', '/')->willReturn([
-            0 => 3
+            0 => 3,
         ])->shouldBeCalled();
 
         $dispatcher = new Dispatcher($router->reveal());

--- a/tests/EventFlowTest.php
+++ b/tests/EventFlowTest.php
@@ -6,8 +6,6 @@ use FastRoute;
 use Penny\Config\Loader;
 use Penny\App;
 use Penny\Container;
-use Penny\Exception\MethodNotAllowed;
-use Penny\Exception\RouteNotFound;
 use PHPUnit_Framework_TestCase;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Response;
@@ -27,7 +25,8 @@ class EventFlowTest extends PHPUnit_Framework_TestCase
         $this->app = new App(Container\PHPDiFactory::buildContainer($config));
     }
 
-    public function testStopEventFlow() {
+    public function testStopEventFlow()
+    {
         $request = (new Request())
         ->withUri(new Uri('/'))
         ->withMethod('GET');
@@ -44,6 +43,7 @@ class EventFlowTest extends PHPUnit_Framework_TestCase
             $response = $response->withStatus(205);
             $e->setResponse($response);
             $e->stopPropagation();
+
             return $response;
         }, 200);
 

--- a/tests/Http/SymfonyKernelTest.php
+++ b/tests/Http/SymfonyKernelTest.php
@@ -1,4 +1,5 @@
 <?php
+
 namespace PennyTest\Http;
 
 use Penny\App;
@@ -19,7 +20,7 @@ class SymfonyKernelTest extends \PHPUnit_Framework_TestCase
             $r->addRoute('GET', '/', [get_class($this), 'index']);
         });
         $config['dispatcher'] = \Di\object('PennyTest\Utils\FastSymfonyDispatcher')
-            ->constructor(\Di\get("router"));
+            ->constructor(\Di\get('router'));
 
         $this->app = new App(Container\PHPDiFactory::buildContainer($config));
     }
@@ -29,12 +30,12 @@ class SymfonyKernelTest extends \PHPUnit_Framework_TestCase
         $requestTest = null;
         $responseTest = null;
 
-        $this->app->getContainer()->get("event_manager")->attach("symfonykerneltest.index_error", function ($e) use (&$requestTest, &$responseTest) {
+        $this->app->getContainer()->get('event_manager')->attach('symfonykerneltest.index_error', function ($e) use (&$requestTest, &$responseTest) {
             $requestTest = $e->getRequest();
             $responseTest = $e->getResponse();
         });
 
-        $request = Request::create("/", "GET");
+        $request = Request::create('/', 'GET');
         $response = new Response();
         $this->app->run($request, $response);
         $this->assertSame($request, $requestTest);


### PR DESCRIPTION
A configuration for the php-cs-fixer is required, quoting from: https://github.com/FriendsOfPHP/PHP-CS-Fixer/issues/1161

> PSR0 force you to name dir 1-1 as you name a namespace, and PSR2 follows PSR0

Fixes https://github.com/pennyphp/penny/issues/64
