### PR TITLE
Standard dispatch result

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,11 +8,11 @@
         "http-flow"
     ],
     "require": {
-	"php": ">=5.5",
+        "php": ">=5.5",
         "nikic/fast-route": "~0.4",
         "php-di/php-di": "~5.0",
         "zendframework/zend-diactoros": "~1.0",
-        "zendframework/zend-eventmanager": "~2.5",
+        "zendframework/zend-eventmanager": "~2.5.0",
         "doctrine/annotations": "^1.2",
         "zendframework/zend-stdlib": "~2.5"
     },

--- a/docs/the-dispatcher-concept.md
+++ b/docs/the-dispatcher-concept.md
@@ -16,11 +16,13 @@ In PHP there are a lot of libraries that do that:
 The [Dispatcher](https://github.com/gianarb/penny/blob/master/src/Dispatcher.php) (click link to show current implementation), in penny represents the link between: router,
 request and response.
 
-The default Penny Dispatcher implementation uses `Zend\Diactoros`. You can write your own dispatcher that makes use of your favorite HTTP library 
+The default Penny Dispatcher implementation uses `Zend\Diactoros`. You can write your own dispatcher that makes use of your favorite HTTP library
 
 Main advantages gained by using `Zend\Diactoros` are:
 * It is supported by the Zend Framework community
 * It follows PSR-7 standard. [(what is PSR-7?)](http://www.php-fig.org/psr/psr-7/)
+
+If the dispatch process is good and exists a callable for your request it returns a RouteInfo implementations.
 
 ## Penny, FastRouter and Symfony\HttpFoundation
 Here we are going to see how to write a dispatcher to use with the `Symfony\HttpFoundation` component.

--- a/src/Container/PHPDiFactory.php
+++ b/src/Container/PHPDiFactory.php
@@ -30,8 +30,9 @@ class PHPDiFactory
                         DI\get('response')
                     ),
                 'event_manager' =>  DI\object('Zend\EventManager\EventManager'),
-                'dispatcher' => DI\object('Penny\Dispatcher')
-                    ->constructor(DI\get('router')),
+                'dispatcher' => DI\factory(function ($container) {
+                    return new \Penny\Dispatcher($container->get('router'), $container);
+                })
             ]
         );
         $builder->addDefinitions($config);

--- a/src/Route/FastPsr7RouteInfo.php
+++ b/src/Route/FastPsr7RouteInfo.php
@@ -1,7 +1,6 @@
 <?php
 namespace Penny\Route;
 
-
 class FastPsr7RouteInfo implements RouteInfoInterface
 {
     private $name;

--- a/src/Route/FastPsr7RouteInfo.php
+++ b/src/Route/FastPsr7RouteInfo.php
@@ -9,7 +9,7 @@ class FastPsr7RouteInfo implements RouteInfoInterface
     private $callable;
     private $params;
 
-    public static function matched($name, $callable, $params = [])
+    public static function matched($name, callable $callable, $params = [])
     {
         if (!is_callable($callable)) {
             throw new InvalidArgumentException('$callable could be only a callable');

--- a/src/Route/FastPsr7RouteInfo.php
+++ b/src/Route/FastPsr7RouteInfo.php
@@ -1,0 +1,33 @@
+<?php
+namespace Penny\Route;
+
+class FastPsr7RouteInfo implements RouteInfoInterface
+{
+    private $name;
+    private $callable;
+    private $params;
+
+    public static function matched($name, callable $callable, $params = [])
+    {
+        $obj = new self();
+        $obj->name = $name;
+        $obj->callable = $callable;
+        $obj->params = $params;
+        return $obj;
+    }
+
+    public function getName()
+    {
+        return $this->name;
+    }
+
+    public function getCallable()
+    {
+        return $this->callable;
+    }
+
+    public function getParams()
+    {
+        return $this->params;
+    }
+}

--- a/src/Route/FastPsr7RouteInfo.php
+++ b/src/Route/FastPsr7RouteInfo.php
@@ -1,14 +1,19 @@
 <?php
 namespace Penny\Route;
 
+use InvalidArgumentException;
+
 class FastPsr7RouteInfo implements RouteInfoInterface
 {
     private $name;
     private $callable;
     private $params;
 
-    public static function matched($name, callable $callable, $params = [])
+    public static function matched($name, $callable, $params = [])
     {
+        if (!is_callable($callable)) {
+            throw new InvalidArgumentException('$callable could be only a callable');
+        }
         $obj = new self();
         $obj->name = $name;
         $obj->callable = $callable;

--- a/src/Route/FastPsr7RouteInfo.php
+++ b/src/Route/FastPsr7RouteInfo.php
@@ -1,7 +1,6 @@
 <?php
 namespace Penny\Route;
 
-use InvalidArgumentException;
 
 class FastPsr7RouteInfo implements RouteInfoInterface
 {
@@ -11,9 +10,6 @@ class FastPsr7RouteInfo implements RouteInfoInterface
 
     public static function matched($name, callable $callable, $params = [])
     {
-        if (!is_callable($callable)) {
-            throw new InvalidArgumentException('$callable could be only a callable');
-        }
         $obj = new self();
         $obj->name = $name;
         $obj->callable = $callable;

--- a/src/Route/RouteInfoInterface.php
+++ b/src/Route/RouteInfoInterface.php
@@ -3,7 +3,7 @@ namespace Penny\Route;
 
 interface RouteInfoInterface
 {
-    public static function matched($name, $callable, $params);
+    public static function matched($name, callable $callable, $params);
     public function getName();
     public function getCallable();
     public function getParams();

--- a/src/Route/RouteInfoInterface.php
+++ b/src/Route/RouteInfoInterface.php
@@ -1,0 +1,10 @@
+<?php
+namespace Penny\Route;
+
+interface RouteInfoInterface
+{
+    public static function matched($name, callable $callable, $params);
+    public function getName();
+    public function getCallable();
+    public function getParams();
+}

--- a/src/Route/RouteInfoInterface.php
+++ b/src/Route/RouteInfoInterface.php
@@ -3,7 +3,7 @@ namespace Penny\Route;
 
 interface RouteInfoInterface
 {
-    public static function matched($name, callable $callable, $params);
+    public static function matched($name, $callable, $params);
     public function getName();
     public function getCallable();
     public function getParams();

--- a/tests/DiTest.php
+++ b/tests/DiTest.php
@@ -14,13 +14,12 @@ use Zend\Diactoros\Uri;
 class DiTest extends PHPUnit_Framework_TestCase
 {
     private $container;
-    private $router;
 
     public function setUp()
     {
         $config = Loader::load();
-        $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'diTest']);
+        $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $routeCollector) {
+            $routeCollector->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'diTest']);
         });
 
         $this->container = Container\PHPDiFactory::buildContainer($config);

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -7,6 +7,7 @@ use Penny\Dispatcher;
 use PHPUnit_Framework_TestCase;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Uri;
+use Penny\Container\PHPDiFactory;
 
 class DispatcherTest extends PHPUnit_Framework_TestCase
 {
@@ -29,7 +30,7 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
 
     public function testSetRouter()
     {
-        $dispatcher = new Dispatcher($this->router);
+        $dispatcher = new Dispatcher($this->router, PHPDiFactory::buildContainer());
         $this->assertInstanceof("FastRoute\Dispatcher\GroupCountBased", \PHPUnit_Framework_Assert::readAttribute($dispatcher, 'router'));
     }
 
@@ -40,7 +41,7 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
         ->withUri(new Uri('/doh'))
         ->withMethod('GET');
 
-        $dispatcher = new Dispatcher($this->router);
+        $dispatcher = new Dispatcher($this->router, PHPDiFactory::buildContainer());
         $dispatcher($request);
     }
 
@@ -51,7 +52,7 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
         ->withUri(new Uri('/'))
         ->withMethod('POST');
 
-        $dispatcher = new Dispatcher($this->router);
+        $dispatcher = new Dispatcher($this->router, PHPDiFactory::buildContainer());
         $dispatcher($request);
     }
 
@@ -59,7 +60,8 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
     {
         $this->setExpectedException('Exception');
 
-        $router = $this->prophesize('FastRoute\Dispatcher');
+        $router = $this->prophesize('FastRoute\Dispatcher', PHPDiFactory::buildContainer());
+        $container = $this->prophesize('Interop\Container\ContainerInterface', PHPDiFactory::buildContainer());
         $request = (new Request())
         ->withUri(new Uri('/'))
         ->withMethod('POST');
@@ -68,7 +70,7 @@ class DispatcherTest extends PHPUnit_Framework_TestCase
             0 => 3,
         ])->shouldBeCalled();
 
-        $dispatcher = new Dispatcher($router->reveal());
+        $dispatcher = new Dispatcher($router->reveal(), $container->reveal());
         $dispatcher($request);
     }
 }

--- a/tests/Http/SymfonyKernelTest.php
+++ b/tests/Http/SymfonyKernelTest.php
@@ -8,6 +8,7 @@ use Penny\Config\Loader;
 use FastRoute;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
+use TestApp\Controller\IndexController;
 
 class SymfonyKernelTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,7 +21,7 @@ class SymfonyKernelTest extends \PHPUnit_Framework_TestCase
             $r->addRoute('GET', '/', [get_class($this), 'index']);
         });
         $config['dispatcher'] = \Di\object('PennyTest\Utils\FastSymfonyDispatcher')
-            ->constructor(\Di\get('router'));
+            ->constructor(\Di\get('router'), \Di\get('di'));
 
         $this->app = new App(Container\PHPDiFactory::buildContainer($config));
     }
@@ -30,7 +31,7 @@ class SymfonyKernelTest extends \PHPUnit_Framework_TestCase
         $requestTest = null;
         $responseTest = null;
 
-        $this->app->getContainer()->get('event_manager')->attach('symfonykerneltest.index_error', function ($e) use (&$requestTest, &$responseTest) {
+        $this->app->getContainer()->get('event_manager')->attach('ERROR_DISPATCH', function ($e) use (&$requestTest, &$responseTest) {
             $requestTest = $e->getRequest();
             $responseTest = $e->getResponse();
         });

--- a/tests/Route/RouteInfoTest.php
+++ b/tests/Route/RouteInfoTest.php
@@ -1,0 +1,27 @@
+<?php
+namespace PennyTest\Route;
+
+use PHPUnit_Framework_TestCase;
+use Penny\Route\FastPsr7RouteInfo;
+use Penny\Route\RouteInfoInterface;
+use TestApp\Controller\IndexController;
+
+class RouteInfoTest extends PHPUnit_Framework_TestCase
+{
+    public function testRouteInfoImplementInterface()
+    {
+        $routeInfo = new FastPsr7RouteInfo();
+        $this->assertInstanceOf(RouteInfoInterface::class, $routeInfo);
+    }
+
+    public function testMatched()
+    {
+        $fastRouteInfo = [
+            [],
+            [new IndexController(), 'index'],
+            ["id" => 5]
+        ];
+        $routeInfo = FastPsr7RouteInfo::matched("index.try", $fastRouteInfo[1], $fastRouteInfo[2]);
+        $this->assertSame("index.try", $routeInfo->getName());
+    }
+}

--- a/tests/Utils/FastSymfonyDispatcher.php
+++ b/tests/Utils/FastSymfonyDispatcher.php
@@ -3,21 +3,25 @@
 namespace PennyTest\Utils;
 
 use Symfony\Component\HttpFoundation\Request;
+use Penny\Route\FastPsr7RouteInfo;
+use ReflectionClass;
 
 class FastSymfonyDispatcher
 {
     private $router;
+    private $container;
 
-    public function __construct($router)
+    public function __construct($router, $container)
     {
         $this->router = $router;
+        $this->container = $container;
     }
 
     public function __invoke(Request $request)
     {
-        $routeInfo = $this->router
+        $fastRouteInfo = $this->router
             ->dispatch($request->getMethod(), $request->getPathInfo());
-        switch ($routeInfo[0]) {
+        switch ($fastRouteInfo[0]) {
             case \FastRoute\Dispatcher::NOT_FOUND:
                 throw new \Penny\Exception\RouteNotFound();
                 break;
@@ -25,6 +29,12 @@ class FastSymfonyDispatcher
                 throw new \Penny\Exception\MethodNotAllowed();
                 break;
             case \FastRoute\Dispatcher::FOUND:
+                $controller = $this->container->get($fastRouteInfo[1][0]);
+                $method = $fastRouteInfo[1][1];
+                $function = (new ReflectionClass($controller))->getShortName();
+
+                $eventName = sprintf('%s.%s', strtolower($function), $method);
+                $routeInfo = FastPsr7RouteInfo::matched($eventName, [$controller, $fastRouteInfo[1][1]], $fastRouteInfo[2]);
                 return $routeInfo;
                 break;
             default:

--- a/tests/Utils/FastSymfonyDispatcher.php
+++ b/tests/Utils/FastSymfonyDispatcher.php
@@ -34,7 +34,10 @@ class FastSymfonyDispatcher
                 $function = (new ReflectionClass($controller))->getShortName();
 
                 $eventName = sprintf('%s.%s', strtolower($function), $method);
-                $routeInfo = FastPsr7RouteInfo::matched($eventName, [$controller, $fastRouteInfo[1][1]], $fastRouteInfo[2]);
+                $callback = function($controller, $fastRouteInfo) {
+                    return call_user_func([$controller, $fastRouteInfo[1][1]]);
+                };
+                $routeInfo = FastPsr7RouteInfo::matched($eventName, $callback($controller, $fastRouteInfo[1][1]), $fastRouteInfo[2]);
                 return $routeInfo;
                 break;
             default:


### PR DESCRIPTION
This PR implements a new class `RouteInfo` to return a standard result of `disptach` method.

This object describe current route resolved by dispatcher and helps us to implement new router libraries.

Reference #16
