### PR TITLE
Drop static RouteInfo matched method

### DIFF
--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -6,27 +6,26 @@ use Interop\Container\ContainerInterface;
 use Exception;
 use ReflectionClass;
 use FastRoute\Dispatcher as BaseDispatcher;
-use FastRoute\Dispatcher as FastRouterDispatcherInterface;
-use Penny\Route\FastPsr7RouteInfo;
 use Penny\Exception\MethodNotAllowed;
 use Penny\Exception\RouteNotFound;
 use Psr\Http\Message\RequestInterface;
+use Penny\Route\RouteInfo;
 
 class Dispatcher
 {
     /**
      * Inner dispatcher.
      *
-     * @var FastRouterDispatcherInterface
+     * @var BaseDispatcher
      */
     private $router;
 
     /**
      * Class constructor with required FastRoute dispatcher implementation.
      *
-     * @param FastRouterDispatcherInterface $router Inner router (based on Nikic FastRouter).
+     * @param BaseDispatcher $router Inner router (based on Nikic FastRouter).
      */
-    public function __construct(FastRouterDispatcherInterface $router, ContainerInterface $container)
+    public function __construct(BaseDispatcher $router, ContainerInterface $container)
     {
         $this->router = $router;
         $this->container = $container;
@@ -62,10 +61,10 @@ class Dispatcher
             case BaseDispatcher::FOUND:
                 $controller = $this->container->get($routeInfo[1][0]);
                 $method = $routeInfo[1][1];
-                $function = (new ReflectionClass($controller))->getShortName();
+                $function = strtolower((new ReflectionClass($controller))->getShortName());
+                $eventName = "{$function}.{$method}"; // this improve ~1us
 
-                $eventName = sprintf('%s.%s', strtolower($function), $method);
-                $routeInfo = FastPsr7RouteInfo::matched($eventName, [$controller, $routeInfo[1][1]], $routeInfo[2]);
+                $routeInfo = new RouteInfo($eventName, [$controller, $routeInfo[1][1]], $routeInfo[2]);
                 return $routeInfo;
             default:
                 throw new Exception(null, 500);

--- a/src/Route/RouteInfo.php
+++ b/src/Route/RouteInfo.php
@@ -1,19 +1,17 @@
 <?php
 namespace Penny\Route;
 
-class FastPsr7RouteInfo implements RouteInfoInterface
+class RouteInfo implements RouteInfoInterface
 {
     private $name;
     private $callable;
     private $params;
 
-    public static function matched($name, callable $callable, $params = [])
+    public function __construct($name, callable $callable, $params = [])
     {
-        $obj = new self();
-        $obj->name = $name;
-        $obj->callable = $callable;
-        $obj->params = $params;
-        return $obj;
+        $this->name = $name;
+        $this->callable = $callable;
+        $this->params = $params;
     }
 
     public function getName()

--- a/src/Route/RouteInfoInterface.php
+++ b/src/Route/RouteInfoInterface.php
@@ -3,7 +3,6 @@ namespace Penny\Route;
 
 interface RouteInfoInterface
 {
-    public static function matched($name, callable $callable, $params);
     public function getName();
     public function getCallable();
     public function getParams();

--- a/tests/Route/RouteInfoTest.php
+++ b/tests/Route/RouteInfoTest.php
@@ -2,26 +2,21 @@
 namespace PennyTest\Route;
 
 use PHPUnit_Framework_TestCase;
-use Penny\Route\FastPsr7RouteInfo;
 use Penny\Route\RouteInfoInterface;
 use TestApp\Controller\IndexController;
+use Penny\Route\RouteInfo;
 
 class RouteInfoTest extends PHPUnit_Framework_TestCase
 {
     public function testRouteInfoImplementInterface()
     {
-        $routeInfo = new FastPsr7RouteInfo();
+        $routeInfo = new RouteInfo('', function(){}, []);
         $this->assertInstanceOf(RouteInfoInterface::class, $routeInfo);
     }
 
     public function testMatched()
     {
-        $fastRouteInfo = [
-            [],
-            [new IndexController(), 'index'],
-            ["id" => 5]
-        ];
-        $routeInfo = FastPsr7RouteInfo::matched("index.try", $fastRouteInfo[1], $fastRouteInfo[2]);
-        $this->assertSame("index.try", $routeInfo->getName());
+        $routeInfo = new RouteInfo('index.try', [new IndexController(), 'index'], ['id' => 5]);
+        $this->assertSame('index.try', $routeInfo->getName());
     }
 }

--- a/tests/Utils/FastSymfonyDispatcher.php
+++ b/tests/Utils/FastSymfonyDispatcher.php
@@ -2,9 +2,9 @@
 
 namespace PennyTest\Utils;
 
-use Symfony\Component\HttpFoundation\Request;
-use Penny\Route\FastPsr7RouteInfo;
 use ReflectionClass;
+use Penny\Route\RouteInfo;
+use Symfony\Component\HttpFoundation\Request;
 
 class FastSymfonyDispatcher
 {
@@ -37,7 +37,7 @@ class FastSymfonyDispatcher
                 $callback = function($controller, $fastRouteInfo) {
                     return call_user_func([$controller, $fastRouteInfo[1][1]]);
                 };
-                $routeInfo = FastPsr7RouteInfo::matched($eventName, $callback($controller, $fastRouteInfo[1][1]), $fastRouteInfo[2]);
+                $routeInfo = new RouteInfo($eventName, $callback($controller, $fastRouteInfo[1][1]), $fastRouteInfo[2]);
                 return $routeInfo;
                 break;
             default:


### PR DESCRIPTION
Just dropped out the `matched` static method in favor of default
constructor.
