### PR TITLE
remove __construct() from PennyEventInterface

### DIFF
--- a/src/Event/PennyEventInterface.php
+++ b/src/Event/PennyEventInterface.php
@@ -7,7 +7,6 @@ use Zend\EventManager\EventInterface;
 
 interface PennyEventInterface extends EventInterface
 {
-    public function __construct($name, $request, $response);
     public function setResponse($response);
     public function getResponse();
     public function setRequest($request);


### PR DESCRIPTION
interface should not dictate how driver class instantiate to object.
