### PR TITLE
Event Manager split interface

### DIFF
--- a/src/Container/PHPDiFactory.php
+++ b/src/Container/PHPDiFactory.php
@@ -29,7 +29,7 @@ class PHPDiFactory
                         DI\get('request'),
                         DI\get('response')
                     ),
-                'event_manager' =>  DI\object('Zend\EventManager\EventManager'),
+                'event_manager' =>  DI\object('Penny\Event\ZendEvmProxy'),
                 'dispatcher' => DI\factory(function ($container) {
                     return new \Penny\Dispatcher($container->get('router'), $container);
                 })

--- a/src/Event/PennyEventInterface.php
+++ b/src/Event/PennyEventInterface.php
@@ -3,10 +3,11 @@ namespace Penny\Event;
 
 use Exception;
 use Penny\Route\RouteInfoInterface;
-use Zend\EventManager\EventInterface;
 
-interface PennyEventInterface extends EventInterface
+interface PennyEventInterface
 {
+    public function getName();
+    public function setName($name);
     public function setResponse($response);
     public function getResponse();
     public function setRequest($request);
@@ -15,4 +16,5 @@ interface PennyEventInterface extends EventInterface
     public function setRouteInfo(RouteInfoInterface $routerInfo);
     public function setException(Exception $exception);
     public function getException();
+    public function stopPropagation($flag = true);
 }

--- a/src/Event/PennyEvmInterface.php
+++ b/src/Event/PennyEvmInterface.php
@@ -1,0 +1,8 @@
+<?php
+namespace Penny\Event;
+
+interface PennyEvmInterface
+{
+    public function trigger(PennyEventInterface $event);
+    public function attach($eventName, callable $listener);
+}

--- a/src/Event/PennyEvmInterface.php
+++ b/src/Event/PennyEvmInterface.php
@@ -3,6 +3,18 @@ namespace Penny\Event;
 
 interface PennyEvmInterface
 {
+    /**
+     * Triggerer event
+     *
+     * @param PennyEventInterface $event Trigger specific event
+     */
     public function trigger(PennyEventInterface $event);
+
+    /**
+     * Attach new listener at specific event
+     *
+     * @param string $eventName Specific event name
+     * @param callable $listener Function to call
+     */
     public function attach($eventName, callable $listener);
 }

--- a/src/Event/ZendEvmProxy.php
+++ b/src/Event/ZendEvmProxy.php
@@ -1,0 +1,26 @@
+<?php
+namespace Penny\Event;
+
+use Zend\EventManager\EventManager;
+
+class ZendEvmProxy implements PennyEvmInterface
+{
+    private $eventManager;
+
+    public function __construct()
+    {
+        $this->eventManager = new EventManager();
+    }
+
+    public function trigger(PennyEventInterface $event)
+    {
+        $this->eventManager->trigger($event);
+        return $this;
+    }
+
+    public function attach($eventName, callable $listener, $priority = 0)
+    {
+        $this->eventManager->attach($eventName, $listener, $priority);
+        return $this;
+    }
+}

--- a/src/Event/ZendEvmProxy.php
+++ b/src/Event/ZendEvmProxy.php
@@ -5,19 +5,31 @@ use Zend\EventManager\EventManager;
 
 class ZendEvmProxy implements PennyEvmInterface
 {
+    /**
+     * @var EventManager
+     */
     private $eventManager;
 
+    /**
+     * Proxy Zend\EventManager\EventManager
+     */
     public function __construct()
     {
         $this->eventManager = new EventManager();
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function trigger(PennyEventInterface $event)
     {
         $this->eventManager->trigger($event);
         return $this;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     public function attach($eventName, callable $listener, $priority = 0)
     {
         $this->eventManager->attach($eventName, $listener, $priority);


### PR DESCRIPTION
This commit contains set of interfaces to support EventManager
replacement.

Penny\Event\ZendEvmProxy will be moved in a separate repository to
remove forced  Zend\EventManager dependency from penny

@pennyphp/community-review @wdalmut
