### PR TITLE
remove dependency status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 [![Build Status](https://travis-ci.org/pennyphp/penny.svg?branch=master)](https://travis-ci.org/pennyphp/penny)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/pennyphp/penny/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/pennyphp/penny/?branch=master)
 [![Code Coverage](https://scrutinizer-ci.com/g/pennyphp/penny/badges/coverage.png?b=master)](https://scrutinizer-ci.com/g/pennyphp/penny/?branch=master)
-[![Dependency Status](https://www.versioneye.com/user/projects/55dadff98d9c4b0018000466/badge.svg?style=flat)](https://www.versioneye.com/user/projects/55dadff98d9c4b0018000466)
 
 Another PHP Framework made of other components.  
 One penny is valueless but a lot of pennies build an empire.  
@@ -29,4 +28,3 @@ $ php -S 127.0.0.1:8080 -t public
 it's ready! You can visit 127.0.0.1:8080
 
 ## [Projects](http://docs.pennyphp.org/en/latest/use-case/)
-


### PR DESCRIPTION
I don't know why it always shown out of date for penny, i think it not quite relevant and not quite needed to be added. So, I think it can be removed.
