### PR TITLE
rename event adapters

### DIFF
--- a/src/Container/PHPDiFactory.php
+++ b/src/Container/PHPDiFactory.php
@@ -23,7 +23,7 @@ class PHPDiFactory
             [
                 'request' => \Zend\Diactoros\ServerRequestFactory::fromGlobals(),
                 'response' => DI\object('Zend\Diactoros\Response'),
-                'http_flow_event' => DI\object('Penny\Event\HttpFlowEvent')
+                'http_flow_event' => DI\object('Penny\Event\ZendHttpFlowEvent')
                     ->constructor(
                         'bootstrap',
                         DI\get('request'),

--- a/src/Event/CakeHttpFlowEvent.php
+++ b/src/Event/CakeHttpFlowEvent.php
@@ -5,7 +5,7 @@ use Exception;
 use Cake\Event\Event as BaseCakeEvent;
 use Penny\Route\RouteInfoInterface;
 
-class CakeEvent extends BaseCakeEvent implements PennyEventInterface
+class CakeHttpFlowEvent extends BaseCakeEvent implements PennyEventInterface
 {
     /**
      * Representation of an outgoing, client-side request.

--- a/src/Event/ZendHttpFlowEvent.php
+++ b/src/Event/ZendHttpFlowEvent.php
@@ -6,7 +6,7 @@ use Exception;
 use Penny\Route\RouteInfoInterface;
 use Zend\EventManager\Event;
 
-class HttpFlowEvent extends Event implements PennyEventInterface
+class ZendHttpFlowEvent extends Event implements PennyEventInterface
 {
     /**
      * Representation of an outgoing, client-side request.

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -6,7 +6,7 @@ use FastRoute;
 use Interop\Container\ContainerInterface;
 use Penny\App;
 use Penny\Container;
-use Penny\Event\HttpFlowEvent;
+use Penny\Event\ZendHttpFlowEvent;
 use Penny\Exception\MethodNotAllowedException;
 use Penny\Exception\RouteNotFoundException;
 use Penny\Config\Loader;
@@ -229,7 +229,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $dispatcher = function () use ($request) {
             return 'callback';
         };
-        $httpFlowEvent = $this->prophesize(HttpFlowEvent::class);
+        $httpFlowEvent = $this->prophesize(ZendHttpFlowEvent::class);
         $eventManager = $this->prophesize(EventManager::class);
 
         $container->has('router')->willReturn(true);

--- a/tests/Event/CakeEvmProxyTest.php
+++ b/tests/Event/CakeEvmProxyTest.php
@@ -2,7 +2,7 @@
 
 namespace PennyTest\Event;
 
-use Penny\Event\CakeEvent;
+use Penny\Event\CakeHttpFlowEvent;
 use Penny\Event\CakeEvmProxy;
 use PHPUnit_Framework_TestCase;
 
@@ -30,7 +30,7 @@ class CakeEmvProxyTest extends PHPUnit_Framework_TestCase
         $this->evmProxy->attach($eventKey, $listener1, 102);
         $this->evmProxy->attach($eventKey, $listener2, 101);
 
-        $cakeEvent = new CakeEvent($eventKey);
+        $cakeEvent = new CakeHttpFlowEvent($eventKey);
 
         ob_start();
         $this->evmProxy->trigger($cakeEvent);

--- a/tests/Event/CakeHttpFlowEventTest.php
+++ b/tests/Event/CakeHttpFlowEventTest.php
@@ -3,34 +3,43 @@
 namespace PennyTest\Event;
 
 use Exception;
-use Penny\Event\HttpFlowEvent;
+use Penny\Event\CakeHttpFlowEvent;
 use Penny\Route\RouteInfoInterface;
 use PHPUnit_Framework_TestCase;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Uri;
 
-class HttpFlowEventTest extends PHPUnit_Framework_TestCase
+class CakeHttpFlowEventTest extends PHPUnit_Framework_TestCase
 {
-    private $event;
+    /** @var CakeEvent */
+    protected $event;
 
-    public function setUp()
+    protected function setUp()
     {
-        $request = (new Request())
-        ->withUri(new Uri('/'))
-        ->withMethod('GET');
-        $response = new Response();
+        $this->event = new CakeHttpFlowEvent('foo');
+    }
 
-        $this->event = new HttpFlowEvent('http_flow_event', $request, $response);
+    public function testGetName()
+    {
+        $this->assertEquals('foo', $this->event->getName());
     }
 
     public function testGetResponse()
     {
+        $response = new Response();
+        $this->event->setResponse($response);
+
         $this->assertInstanceOf(Response::class, $this->event->getResponse());
     }
 
     public function testGetRequest()
     {
+        $request = (new Request())
+        ->withUri(new Uri('/'))
+        ->withMethod('GET');
+        $this->event->setRequest($request);
+
         $this->assertInstanceOf(Request::class, $this->event->getRequest());
     }
 
@@ -47,5 +56,11 @@ class HttpFlowEventTest extends PHPUnit_Framework_TestCase
         $exception = new Exception();
         $this->event->setException($exception);
         $this->assertSame($exception, $this->event->getException());
+    }
+
+    public function testStopPropagation()
+    {
+        $this->event->stopPropagation(false);
+        $this->assertFalse($this->event->isStopped());
     }
 }

--- a/tests/Event/ZendHttpFlowEventTest.php
+++ b/tests/Event/ZendHttpFlowEventTest.php
@@ -3,43 +3,34 @@
 namespace PennyTest\Event;
 
 use Exception;
-use Penny\Event\CakeEvent;
+use Penny\Event\ZendHttpFlowEvent;
 use Penny\Route\RouteInfoInterface;
 use PHPUnit_Framework_TestCase;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Uri;
 
-class CakeEventTest extends PHPUnit_Framework_TestCase
+class ZendHttpFlowEventTest extends PHPUnit_Framework_TestCase
 {
-    /** @var CakeEvent */
-    protected $event;
+    private $event;
 
-    protected function setUp()
+    public function setUp()
     {
-        $this->event = new CakeEvent('foo');
-    }
+        $request = (new Request())
+        ->withUri(new Uri('/'))
+        ->withMethod('GET');
+        $response = new Response();
 
-    public function testGetName()
-    {
-        $this->assertEquals('foo', $this->event->getName());
+        $this->event = new ZendHttpFlowEvent('http_flow_event', $request, $response);
     }
 
     public function testGetResponse()
     {
-        $response = new Response();
-        $this->event->setResponse($response);
-
         $this->assertInstanceOf(Response::class, $this->event->getResponse());
     }
 
     public function testGetRequest()
     {
-        $request = (new Request())
-        ->withUri(new Uri('/'))
-        ->withMethod('GET');
-        $this->event->setRequest($request);
-
         $this->assertInstanceOf(Request::class, $this->event->getRequest());
     }
 
@@ -56,11 +47,5 @@ class CakeEventTest extends PHPUnit_Framework_TestCase
         $exception = new Exception();
         $this->event->setException($exception);
         $this->assertSame($exception, $this->event->getException());
-    }
-
-    public function testStopPropagation()
-    {
-        $this->event->stopPropagation(false);
-        $this->assertFalse($this->event->isStopped());
     }
 }


### PR DESCRIPTION
more specific, easier to use
- `Event\HttpFlowEvent` to `Event\ZendHttpFlowEvent`
- `Event\CakeEvent` to `Event\CakeHttpFlowEvent`
