### PR TITLE
more improvements

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -51,10 +51,12 @@ Every application has an entry point, `public/index.php` is our.
 // /public/index.php
 
 <?php
+use Penny\App;
+
 chdir(dirname(__DIR__));
 require "vendor/autoload.php";
 
-$app = new \Penny\App();
+$app = new Penny\App();
 $emitter = new \Zend\Diactoros\Response\SapiEmitter();
 $emitter->emit($app->run());
 ```
@@ -62,6 +64,10 @@ $emitter->emit($app->run());
 The `Penny\App` allow us to pass Container that instance of `Interop\Container\ContainerInterface`, if we don't supply any, it will load using PHP DI that will read `./config/{{*}}{{,*.local}}.php` as default. For custom path for config to be read with PHP DI, we can specify:
 
 ```php
+use Penny\App;
+use Penny\Config\Loader;
+use Penny\Container;
+
 $config = Loader::load("./config/{{*}}{{,*.local}}.php");
 $app    = new App(Container\PHPDiFactory::buildContainer($config));
 ```

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -56,7 +56,7 @@ use Penny\App;
 chdir(dirname(__DIR__));
 require "vendor/autoload.php";
 
-$app = new Penny\App();
+$app = new App();
 $emitter = new \Zend\Diactoros\Response\SapiEmitter();
 $emitter->emit($app->run());
 ```

--- a/docs/write-our-event-manager-proxy.md
+++ b/docs/write-our-event-manager-proxy.md
@@ -42,24 +42,23 @@ class OurAwesomeEventManagerProxy implements PennyEvmInterface
 }
 ```
 
-After that, we can register it as service named 'event_manager' in Our favorite container.
+After that, we can register it as service named 'event_manager' in Our favorite container. For example, we use PHP DI that may be facilitated by `Penny\Container\PHPDiFactory` :
 
 ```php
 use App\EventManager\Event\OurAwesomeEventManagerProxy;
 use DI;
+use Penny\App;
+use Penny\Config\Loader;
+use Penny\Container\PHPDiFactory;
+use Zend\Stdlib\ArrayUtils;
 
-$builder = new DI\ContainerBuilder();
-$builder->useAnnotations(true);
-$builder->addDefinitions(
+$config = Loader::load("./config/{{*}}{{,*.local}}.php");
+$config = ArrayUtils::merge(
     [
         'event_manager' =>  DI\object(OurAwesomeEventManagerProxy::class),
-        // other services definition here
-        // see https://github.com/pennyphp/penny/blob/master/src/Container/PHPDiFactory.php
-    ]
+    ],
+    $config
 );
-$builder->addDefinitions($config);
-$container = $builder->build();
-$container->set('di', $container);
 
-$app = new App($container);
+$app = new App(PHPDiFactory::buildContainer($config));
 ```

--- a/docs/write-our-event-manager-proxy.md
+++ b/docs/write-our-event-manager-proxy.md
@@ -42,7 +42,7 @@ class OurAwesomeEventManagerProxy implements PennyEvmInterface
 }
 ```
 
-After that, we can register it as service named 'event_manager' in Our favorite container. For example, we use PHP DI that may be facilitated by `Penny\Container\PHPDiFactory` :
+After that, we can register it as service named 'event_manager' in Our favorite container. For example, we use PHP-DI that may be facilitated by `Penny\Container\PHPDiFactory` :
 
 ```php
 use App\EventManager\Event\OurAwesomeEventManagerProxy;

--- a/src/App.php
+++ b/src/App.php
@@ -22,7 +22,7 @@ class App
     /**
      * Application initialization.
      *
-     * @param ContainerInterface|\DI\Container $container Dependency Injection container.
+     * @param ContainerInterface $container Dependency Injection container.
      *
      * @throws Exception If no router is defined.
      */

--- a/src/App.php
+++ b/src/App.php
@@ -22,7 +22,7 @@ class App
     /**
      * Application initialization.
      *
-     * @param ContainerInterface $container Dependency Injection container.
+     * @param ContainerInterface|\DI\Container $container Dependency Injection container.
      *
      * @throws Exception If no router is defined.
      */

--- a/src/Container/PHPDiFactory.php
+++ b/src/Container/PHPDiFactory.php
@@ -19,7 +19,7 @@ class PHPDiFactory
      *
      * @link http://php-di.org/doc/php-definitions.html
      *
-     * @return ContainerInterface
+     * @return DI\Container
      */
     public static function buildContainer($config = [], $annotation = true)
     {

--- a/src/Container/PHPDiFactory.php
+++ b/src/Container/PHPDiFactory.php
@@ -3,6 +3,11 @@
 namespace Penny\Container;
 
 use DI;
+use Penny\Dispatcher;
+use Penny\Event\ZendHttpFlowEvent;
+use Penny\Event\ZendEvmProxy;
+use Zend\Diactoros\Response;
+use Zend\Diactoros\ServerRequestFactory;
 
 class PHPDiFactory
 {
@@ -10,35 +15,45 @@ class PHPDiFactory
      * Container compilation.
      *
      * @param mixed $config Configuration file/array.
+     * @param bool $annotation annotation usage.
      *
      * @link http://php-di.org/doc/php-definitions.html
      *
      * @return ContainerInterface
      */
-    public static function buildContainer($config = [])
+    public static function buildContainer($config = [], $annotation = true)
     {
-        $builder = new DI\ContainerBuilder();
-        $builder->useAnnotations(true);
-        $builder->addDefinitions(
-            [
-                'request' => \Zend\Diactoros\ServerRequestFactory::fromGlobals(),
-                'response' => DI\object('Zend\Diactoros\Response'),
-                'http_flow_event' => DI\object('Penny\Event\ZendHttpFlowEvent')
-                    ->constructor(
-                        'bootstrap',
-                        DI\get('request'),
-                        DI\get('response')
-                    ),
-                'event_manager' => DI\object('Penny\Event\ZendEvmProxy'),
-                'dispatcher' => DI\factory(function ($container) {
-                    return new \Penny\Dispatcher($container->get('router'), $container);
-                }),
-            ]
-        );
+        $builder = static::initialSetupContainerBuilder($annotation);
         $builder->addDefinitions($config);
+
         $container = $builder->build();
         $container->set('di', $container);
 
         return $container;
+    }
+
+    /**
+     * Initial setup of DI\ContainerBuilder.
+     *
+     * @param bool $annotation annotation usage.
+     *
+     * @return DI\ContainerBuilder
+     */
+    protected static function initialSetupContainerBuilder($annotation)
+    {
+        $builder = new DI\ContainerBuilder();
+        $builder->useAnnotations($annotation);
+        $builder->addDefinitions([
+            'request' => ServerRequestFactory::fromGlobals(),
+            'response' => DI\object(Response::class),
+            'http_flow_event' => DI\object(ZendHttpFlowEvent::class)
+                ->constructor('bootstrap', DI\get('request'), DI\get('response')),
+            'event_manager' => DI\object(ZendEvmProxy::class),
+            'dispatcher' => DI\factory(function ($container) {
+                return new Dispatcher($container->get('router'), $container);
+            }),
+        ]);
+
+        return $builder;
     }
 }


### PR DESCRIPTION
- PHPDiFactory refactor to allow set `useAnnotations` when call:

``` php
PHPDiFactory::buildContainer($config, true);
```

uses 2nd parameter to set it.
- EventManager documentation and its usage with PHPDiFactory
- Fixes missing use statements in getting started documentation.
