### PR TITLE
Fixes RouteInfoInterface type hint in handleRoute() method

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -133,15 +133,13 @@ class App
     /**
      * Handle Route.
      *
-     * @param RouteInfoInterface $routeInfo
+     * @param $routeInfo
      * @param PennyEventInterface $event
      *
      * @throws RuntimeException if dispatch does not return RouteInfo object.
      */
-    private function handleRoute(
-        RouteInfoInterface $routeInfo,
-        PennyEventInterface $event
-    ) {
+    private function handleRoute($routeInfo, PennyEventInterface $event)
+    {
         if (!$routeInfo instanceof RouteInfoInterface) {
             throw new RuntimeException('Dispatch does not return RouteInfo object');
         }

--- a/src/App.php
+++ b/src/App.php
@@ -133,7 +133,7 @@ class App
     /**
      * Handle Route.
      *
-     * @param $routeInfo
+     * @param mixed $routeInfo
      * @param PennyEventInterface $event
      *
      * @throws RuntimeException if dispatch does not return RouteInfo object.


### PR DESCRIPTION
as the `RouteInfoInterface` type hint make `RuntimeException` never executed. It fixes now ;)
