### PR TITLE
make bootstrap event triggered in App::run()

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -118,6 +118,8 @@ class App
         $dispatcher   = $this->getDispatcher();
         $eventManager = $this->getEventManager();
 
+        $eventManager->trigger($event);
+
         try {
             $routeInfo = call_user_func($dispatcher, $event->getRequest());
             $this->handleRoute($routeInfo, $event);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -241,4 +241,24 @@ class AppTest extends PHPUnit_Framework_TestCase
         $app = new App($container->reveal());
         $response = $app->run($request, $response);
     }
+
+    public function testBootstrapEventTriggered()
+    {
+        $config = Loader::load();
+        $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
+            $r->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'index']);
+        });
+        $this->app = new App(Container\PHPDiFactory::buildContainer($config));
+        $this->app->getContainer()
+                  ->get('event_manager')
+                  ->attach('bootstrap', function() {
+                       echo 'bootstrap triggered';
+                  });
+
+        ob_start();
+        $this->app->run();
+        $content = ob_get_clean();
+
+        $this->assertEquals('bootstrap triggered', $content);
+    }
 }


### PR DESCRIPTION
@gianarb the initial event is named 'bootstrap', it need to be called in `App::run()` before the event replaced in next move to make it usable.
