### PR TITLE
Fixes #96 , implements ClassName::class prefix for event name

### DIFF
--- a/docs/flow.md
+++ b/docs/flow.md
@@ -20,10 +20,10 @@ If a route matches, the corresponding callback is invoked, in this case the call
 $r->addRoute('GET', '/', ['PennyApp\Controller\IndexController', 'index']);
 ```
 
-At this point the system triggers an event called `indexcontroller.index` with zero priority and execute the route callback.
+At this point the system triggers an event called `PennyApp\Controller\IndexController.index` with zero priority and execute the route callback.
 
 All listeners attached after and before it will be called correctly until the framework returns response,
-if an exception is thrown it will trigger an event named `indexcontroller.index_error`.
+if an exception is thrown it will trigger an event named `PennyApp\Controller\IndexController.index_error`.
 
 The most common way to manage all exceptions is:
 

--- a/src/App.php
+++ b/src/App.php
@@ -162,7 +162,8 @@ class App
         EventInterface $event,
         RouteInfoInterface $routeInfo
     ) {
-        $eventManager->attach($event->getName(), function ($event) use ($routeInfo) {
+        $eventName = $event->getName();
+        $eventManager->attach($eventName, function ($event) use ($routeInfo) {
             $event->setResponse(call_user_func_array(
                 $routeInfo->getCallable(),
                 [$event->getRequest(), $event->getResponse()] + $routeInfo->getParams()
@@ -172,7 +173,7 @@ class App
         try {
             $eventManager->trigger($event);
         } catch (Exception $exception) {
-            $this->triggerWithException($eventManager, $event, $routeInfo->getName().'_error', $exception);
+            $this->triggerWithException($eventManager, $event, $eventName.'_error', $exception);
         }
     }
 

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -85,7 +85,7 @@ class Dispatcher
         $controller = $this->container->get($dispatch[1][0]);
         $method = $dispatch[1][1];
         $params = $dispatch[2];
-        $function = strtolower((new ReflectionClass($controller))->getShortName());
+        $function = (new ReflectionClass($controller))->getName();
         $eventName = "{$function}.{$method}"; // this improve ~1us
 
         return new RouteInfo($eventName, [$controller, $method], $params);

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -85,7 +85,7 @@ class Dispatcher
         $controller = $this->container->get($dispatch[1][0]);
         $method = $dispatch[1][1];
         $params = $dispatch[2];
-        $function = (new ReflectionClass($controller))->getName();
+        $function = (new ReflectionClass($controller))->name;
         $eventName = "{$function}.{$method}"; // this improve ~1us
 
         return new RouteInfo($eventName, [$controller, $method], $params);

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -12,6 +12,7 @@ use Penny\Exception\MethodNotAllowedException;
 use Penny\Exception\RouteNotFoundException;
 use Penny\Config\Loader;
 use PHPUnit_Framework_TestCase;
+use TestApp\Controller\IndexController;
 use stdClass;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Response;
@@ -26,10 +27,10 @@ class AppTest extends PHPUnit_Framework_TestCase
     {
         $config = Loader::load();
         $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'index']);
-            $r->addRoute('GET', '/{id:\d+}', ['TestApp\Controller\IndexController', 'getSingle']);
-            $r->addRoute('GET', '/fail', ['TestApp\Controller\IndexController', 'failed']);
-            $r->addRoute('GET', '/dummy', ['TestApp\Controller\IndexController', 'dummy']);
+            $r->addRoute('GET', '/', [IndexController::class, 'index']);
+            $r->addRoute('GET', '/{id:\d+}', [IndexController::class, 'getSingle']);
+            $r->addRoute('GET', '/fail', [IndexController::class, 'failed']);
+            $r->addRoute('GET', '/dummy', [IndexController::class, 'dummy']);
         });
 
         $this->app = new App(Container\PHPDiFactory::buildContainer($config));
@@ -101,7 +102,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ->withMethod('GET');
         $response = new Response();
 
-        $this->app->getContainer()->get('event_manager')->attach('indexcontroller.index', function ($e) {
+        $this->app->getContainer()->get('event_manager')->attach(IndexController::class.'.index', function ($e) {
             $response = $e->getResponse();
             $response->getBody()->write("I'm very happy!");
             $e->setResponse($response);
@@ -119,7 +120,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         ->withMethod('GET');
         $response = new Response();
 
-        $this->app->getContainer()->get('event_manager')->attach('indexcontroller.index', function ($e) {
+        $this->app->getContainer()->get('event_manager')->attach(IndexController::class.'.index', function ($e) {
             $response = $e->getResponse();
             $response->getBody()->write('This is');
             $e->setResponse($response);
@@ -139,7 +140,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $response = new Response();
         $count = 0;
 
-        $this->app->getContainer()->get('event_manager')->attach('indexcontroller.dummy_error', function ($e) use (&$count) {
+        $this->app->getContainer()->get('event_manager')->attach(IndexController::class.'.dummy_error', function ($e) use (&$count) {
             $count = &$count + 1;
             throw $e->getException();
         }, 10);
@@ -181,7 +182,7 @@ class AppTest extends PHPUnit_Framework_TestCase
 
         $config = Loader::load();
         $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'index']);
+            $r->addRoute('GET', '/', [IndexController::class, 'index']);
         });
         $config['dispatcher'] = new \StdClass();
 
@@ -246,7 +247,7 @@ class AppTest extends PHPUnit_Framework_TestCase
     {
         $config = Loader::load();
         $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'index']);
+            $r->addRoute('GET', '/', [IndexController::class, 'index']);
         });
         $this->app = new App(Container\PHPDiFactory::buildContainer($config));
         $this->app->getContainer()

--- a/tests/EventFlowTest.php
+++ b/tests/EventFlowTest.php
@@ -7,6 +7,7 @@ use Penny\Config\Loader;
 use Penny\App;
 use Penny\Container;
 use PHPUnit_Framework_TestCase;
+use TestApp\Controller\IndexController;
 use Zend\Diactoros\Request;
 use Zend\Diactoros\Response;
 use Zend\Diactoros\Uri;
@@ -19,7 +20,7 @@ class EventFlowTest extends PHPUnit_Framework_TestCase
     {
         $config = Loader::load();
         $config['router'] = FastRoute\simpleDispatcher(function (FastRoute\RouteCollector $r) {
-            $r->addRoute('GET', '/', ['TestApp\Controller\IndexController', 'index']);
+            $r->addRoute('GET', '/', [IndexController::class, 'index']);
         });
 
         $this->app = new App(Container\PHPDiFactory::buildContainer($config));
@@ -32,13 +33,13 @@ class EventFlowTest extends PHPUnit_Framework_TestCase
         ->withMethod('GET');
         $response = new Response();
 
-        $this->app->getContainer()->get('event_manager')->attach('indexcontroller.index', function ($e) {
+        $this->app->getContainer()->get('event_manager')->attach(IndexController::class.'.index', function ($e) {
             $response = $e->getResponse();
             $response = $response->withStatus(201);
             $e->setResponse($response);
         }, 100);
 
-        $this->app->getContainer()->get('event_manager')->attach('indexcontroller.index', function ($e) {
+        $this->app->getContainer()->get('event_manager')->attach(IndexController::class.'.index', function ($e) {
             $response = $e->getResponse();
             $response = $response->withStatus(205);
             $e->setResponse($response);


### PR DESCRIPTION
@gianarb Fixes #96 here we go ;). new format:
- `App\Controller\IndexController.index` for 200 status
- `App\Controller\IndexController.dummy_error` for throwing Exception

For `dispatch_error`, we can't have ClassName::class as prefix, as it means no controller registered.
