### PR TITLE
Fixes #148

### DIFF
--- a/src/App.php
+++ b/src/App.php
@@ -58,7 +58,13 @@ class App
     {
         $dispatcher = $this->container->get('dispatcher');
         if (!is_callable($dispatcher)) {
-            throw new \RuntimeException('Dispatcher must be a callable');
+            throw new RuntimeException('Dispatcher must be a callable');
+        }
+        if (!$dispatcher instanceof Dispatcher) {
+            throw new RuntimeException(sprintf(
+                'Dispatcher must be an instance of %s\Dispatcher class',
+                __NAMESPACE__
+            ));
         }
 
         return $dispatcher;
@@ -122,7 +128,8 @@ class App
 
         try {
             $routeInfo = call_user_func($dispatcher, $event->getRequest());
-            $this->handleRoute($routeInfo, $event);
+            $event->setRouteInfo($routeInfo);
+            $event->setName($routeInfo->getName());
         } catch (Exception $exception) {
             return $this->triggerWithException($eventManager, $event, 'dispatch_error', $exception)
                         ->getResponse();
@@ -130,24 +137,6 @@ class App
         $this->handleResponse($eventManager, $event, $routeInfo);
 
         return $event->getResponse();
-    }
-
-    /**
-     * Handle Route.
-     *
-     * @param mixed $routeInfo
-     * @param EventInterface $event
-     *
-     * @throws RuntimeException if dispatch does not return RouteInfo object.
-     */
-    private function handleRoute($routeInfo, EventInterface $event)
-    {
-        if (!$routeInfo instanceof RouteInfoInterface) {
-            throw new RuntimeException('Dispatch does not return RouteInfo object');
-        }
-
-        $event->setRouteInfo($routeInfo);
-        $event->setName($routeInfo->getName());
     }
 
     /**

--- a/src/Dispatcher.php
+++ b/src/Dispatcher.php
@@ -8,7 +8,6 @@ use ReflectionClass;
 use FastRoute\Dispatcher as BaseDispatcher;
 use Penny\Exception\MethodNotAllowedException;
 use Penny\Exception\RouteNotFoundException;
-use Psr\Http\Message\RequestInterface;
 use Penny\Route\RouteInfo;
 
 class Dispatcher
@@ -42,7 +41,7 @@ class Dispatcher
     /**
      * Dispatching.
      *
-     * @param RequestInterface $request Representation of an outgoing,
+     * @param mixed $request Representation of an outgoing,
      *                                  client-side request.
      *
      * @throws RouteNotFoundException    If the route is not found.
@@ -51,7 +50,7 @@ class Dispatcher
      *
      * @return RouteInfo
      */
-    public function __invoke(RequestInterface $request)
+    public function __invoke($request)
     {
         $router = $this->router;
         $uri = $request->getUri();

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -219,7 +219,7 @@ class AppTest extends PHPUnit_Framework_TestCase
         $response = $app->run($request, $response);
     }
 
-    public function testRouteInfoNotInstanceOfRouteInfoInterface()
+    public function testDispatcherNotInstanceOfPennyDispatcher()
     {
         $this->setExpectedException('RuntimeException', 'Dispatcher must be an instance of Penny\Dispatcher class');
 

--- a/tests/AppTest.php
+++ b/tests/AppTest.php
@@ -170,11 +170,10 @@ class AppTest extends PHPUnit_Framework_TestCase
         $this->assertEquals(405, $response->getStatusCode());
     }
 
-    /**
-     * @expectedException \RuntimeException
-     */
     public function testDispatcherShouldBeCallable()
     {
+        $this->setExpectedException('RuntimeException', 'Dispatcher must be a callable');
+
         $request = (new ServerRequest())
         ->withUri(new Uri('/'))
         ->withMethod('POST');
@@ -206,7 +205,7 @@ class AppTest extends PHPUnit_Framework_TestCase
 
     public function testHttpFlowEventNotInstanceOfEventInterface()
     {
-        $this->setExpectedException('RuntimeException');
+        $this->setExpectedException('RuntimeException', 'This event did not supported');
 
         chdir(__DIR__.'/app');
         $app = new App();
@@ -222,6 +221,8 @@ class AppTest extends PHPUnit_Framework_TestCase
 
     public function testRouteInfoNotInstanceOfRouteInfoInterface()
     {
+        $this->setExpectedException('RuntimeException', 'Dispatcher must be an instance of Penny\Dispatcher class');
+
         $container = $this->prophesize(ContainerInterface::class);
         $request = (new ServerRequest())
         ->withUri(new Uri('/'))

--- a/tests/Utils/FastSymfonyDispatcher.php
+++ b/tests/Utils/FastSymfonyDispatcher.php
@@ -3,21 +3,13 @@
 namespace PennyTest\Utils;
 
 use ReflectionClass;
+use Penny\Dispatcher;
 use Penny\Route\RouteInfo;
 use Symfony\Component\HttpFoundation\Request;
 
-class FastSymfonyDispatcher
+class FastSymfonyDispatcher extends Dispatcher
 {
-    private $router;
-    private $container;
-
-    public function __construct($router, $container)
-    {
-        $this->router = $router;
-        $this->container = $container;
-    }
-
-    public function __invoke(Request $request)
+    public function __invoke($request)
     {
         $fastRouteInfo = $this->router
             ->dispatch($request->getMethod(), $request->getPathInfo());


### PR DESCRIPTION
Actually, the check should happen for Dispatcher instead of RouteInfo as if Dispatcher class executed, it must return RouteInfo or throw Exception in the switch case at https://github.com/pennyphp/penny/blob/master/src/Dispatcher.php#L64-L73, so, placing check should be 

``` php
   if (!$dispatcher instanceof Dispatcher) {
       throw here....
   } 
```

at `getDispatcher()` method. Hereby a provided fixes ;). In next, the implementation for custom dispatcher must extends `Penny\Dispatcher` class with `mixed $request` in `__invoke($request)`, or we create new interface for Dispatcher ;)
